### PR TITLE
New exercise type for 'conventional' search problems

### DIFF
--- a/search/exercises.py
+++ b/search/exercises.py
@@ -64,7 +64,88 @@ def random_grid_problem(width, height, p_edge=0.5, cost=None, seed=0):
 
         return problem
 
+def sg_sxy(x, y, graph_width):
+    s = 1
+    for y_p in range(y):
+        s += graph_width if y_p % 2 == 0 else graph_width - 1
+    s += x
+    return s
+    
+def sg_find_long_line_neighbours(x, y, width, height):
+    neighbours = []
+    if y % 2 == 0:
+        if(x == 0 or x == width - 1):
+            for y_p in range(0, height, 2):
+                if(y != y_p):
+                    neighbours.append(sg_sxy(x, y_p, width))
+        if(y == 0 or y == height - 1):
+            for x_p in range(0, width, 1):
+                if(x_p < x - 1 or x + 1 < x_p):
+                    neighbours.append(sg_sxy(x_p, y, width))
+    return neighbours
+    
+def sg_find_exa_neighbours(x, y, width, height):
+    neighbours = []
+    w_act = width if y % 2 == 0 else width - 1
+    if(x - 1 >= 0): #LEFT
+        neighbours.append(sg_sxy(x-1, y, width))
+    if(x + 1 < w_act): #RIGHT
+        neighbours.append(sg_sxy(x+1, y, width))
+    if(y % 2 == 0):
+        if(x < width - 1 and y + 1 < height): #Top-Right
+            neighbours.append(sg_sxy(x, y+1, width))
+        if(x < width - 1 and y - 1 >= 0): #Bottom-Right
+            neighbours.append(sg_sxy(x, y-1, width))
+        if(x - 1 >= 0 and y + 1 < height): #Top-Left
+            neighbours.append(sg_sxy(x-1, y+1, width))
+        if(x - 1 >= 0 and y - 1 >= 0): #Bottom-Left
+            neighbours.append(sg_sxy(x-1, y-1, width))
+    else:
+        if(x + 1 < width and y + 1 < height): #Top-Right
+            neighbours.append(sg_sxy(x+1, y+1, width))
+        if(x + 1 < width and y - 1 >= 0): #Bottom-Right
+            neighbours.append(sg_sxy(x+1, y-1, width))
+        if(y + 1 < height): #Top-Left
+            neighbours.append(sg_sxy(x, y+1, width))
+        if(y - 1 >= 0): #Bottom-Left
+            neighbours.append(sg_sxy(x, y-1, width))
+    return neighbours
 
+def strange_grid_problem(width, height, p_edge=0.3, cost=None, seed=0):
+    states = []
+    positions = {}
+    s = 1        
+    for y in range(height):
+        if y % 2 == 0:
+            for x in range(width):
+                states.append(s)
+                positions[s] = (x,y)
+                s += 1
+        else:
+            for x in range(width - 1):
+                states.append(s)
+                positions[s] = (x+0.5,y)
+                s += 1
+     
+    initial = 1
+    goals = {s-1}
+    problem = Problem(states, initial, goals, positions=positions)        
+    np.random.seed(seed)
+    
+    for y in range(height):
+        w_act = width if y % 2 == 0 else width - 1
+        for x in range(w_act):
+            s = sg_sxy(x, y, width)
+            for neighbour in sg_find_exa_neighbours(x, y, width, height) + sg_find_long_line_neighbours(x, y, width, height):
+                if np.random.random() < p_edge:
+                    if cost is not None:
+                        c = np.random.randint(cost[0], cost[1]+1)
+                    else:
+                        c = 1
+                    problem.add_action(s, neighbour, c=c, undir=False)
+
+    return problem    
+    
 named_exercises = {}
 
 ################################################## [SLIDES] TREE EXAMPLES

--- a/search/printers.py
+++ b/search/printers.py
@@ -90,11 +90,10 @@ def pyplot_printer(it, problem, frontier, reached, curr, solution, folder=None, 
         
     
     nx.draw_networkx_labels(G, pos)
-    nx.draw_networkx_edges(G, pos, arrowsize=arrow_size, connectionstyle=f'arc3, rad = 0.25')
+    nx.draw_networkx_edges(G, pos, arrowsize=arrow_size, connectionstyle=f'arc3, rad = 0.15')
 
     costs = {e : G.edges[e]['cost'] for e in G.edges}
     nx.draw_networkx_edge_labels(G, pos, edge_labels=costs)
-
 
     if solution is not None and isinstance(solution, Solution):
         edgelist = []
@@ -102,7 +101,7 @@ def pyplot_printer(it, problem, frontier, reached, curr, solution, folder=None, 
             edgelist.append((solution[i].state, solution[i+1].state))
         
         nx.draw_networkx_edges(G, pos, edgelist=edgelist, width=1.5, edge_color=col_goal,
-                               arrowsize=arrow_size*1.5, connectionstyle=f'arc3, rad = 0.25')
+                               arrowsize=arrow_size*1.5, connectionstyle=f'arc3, rad = 0.15')
 
 
 

--- a/search/search.py
+++ b/search/search.py
@@ -216,8 +216,11 @@ if __name__ == '__main__':
             problem = exercises.random_grid_problem(w, h, p_edge=args.p_edge, cost=args.cost, seed=args.seed)
         elif args.exercise_type == 'sg': 
             problem = exercises.strange_grid_problem(w, h, p_edge=args.p_edge, cost=args.cost, seed=args.seed)
-        else :
+        else:
             raise NotImplementedError(f"Algorithm {args.alg} not implemented.")
+            
+        if args.exercise_type == 'sg' and (args.alg == 'astar' or args.alg == 'greedy'):
+            raise NotImplementedError(f"Algorithm {args.alg} is not intended for sg type")
 
         if args.initial is not None:
             problem.initial = args.initial

--- a/search/search.py
+++ b/search/search.py
@@ -159,6 +159,7 @@ def depth_first(problem, max_steps=100, printer=None):
 if __name__ == '__main__':
 
     import exercises
+    import numpy as np
     from printers import cli_printer, pyplot_printer, debug_printer
 
     import argparse
@@ -166,6 +167,10 @@ if __name__ == '__main__':
 
     parser.add_argument('alg', type=str,
                         help="Algorithm")
+                        
+    parser.add_argument('exercise_type', type=str,
+                        help=f"Type of the exercise: Grid (g) or SpecialGrid (sg)",
+                        default='g')
 
     parser.add_argument('--example', type=str,
                         help=f"One of {exercises.named_exercises}",
@@ -193,9 +198,10 @@ if __name__ == '__main__':
     
     parser.add_argument('--seed', type=int,
                         help="Random seed number",
-                        default=666)
+                        default=int(np.random.random() * 1000))
 
     args = parser.parse_args()
+    print("SEED:", args.seed)
 
     if args.example is not None:
         if args.example in exercises.named_exercises:
@@ -206,7 +212,12 @@ if __name__ == '__main__':
     else:
 
         w, h = map(int, tuple(args.grid_size))
-        problem = exercises.random_grid_problem(w, h, p_edge=args.p_edge, cost=args.cost, seed=args.seed)
+        if args.exercise_type == 'g': 
+            problem = exercises.random_grid_problem(w, h, p_edge=args.p_edge, cost=args.cost, seed=args.seed)
+        elif args.exercise_type == 'sg': 
+            problem = exercises.strange_grid_problem(w, h, p_edge=args.p_edge, cost=args.cost, seed=args.seed)
+        else :
+            raise NotImplementedError(f"Algorithm {args.alg} not implemented.")
 
         if args.initial is not None:
             problem.initial = args.initial


### PR DESCRIPTION
Hello,

I've tried to add a new type of exercise for 'conventional' type of searches.
The idea is to have more neighbours to search instead to have a four-grid, using the algorithms bfs, ucs and dfs. Because the Manhattan distance doesn't work with this type of grid, user is blocked from running the algorithm with greedy search and A*.
A new parameter, exercise_type, is introduced to let the user choose what kind of exercise he wants (classical or new grid).
Default seed randomization in introduced (as in hill_climbing) and display of edges (curve of the edges and arrow size) is modified to avoid overlap of arrows.